### PR TITLE
[Feat] useSuspenseQuery 사용을 위한 환경설정

### DIFF
--- a/app/(landing)/notices/_api/get-notice.ts
+++ b/app/(landing)/notices/_api/get-notice.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/shared/api/axios'
+import { APIResponseBaseModel } from '@/shared/types/response'
 
 export interface NoticeUserModel {
   userId: number
@@ -13,9 +14,7 @@ export interface NoticeModel {
   createdAt: string
 }
 
-interface NoticesResponseModel {
-  isSuccess: boolean
-  message: string
+interface NoticesResponseModel extends APIResponseBaseModel<boolean> {
   result: {
     content: NoticeModel[]
     page: number
@@ -32,13 +31,14 @@ interface Props {
   size?: number
 }
 
-const getNotices = async ({ page = 1, size = 9 }: Props = {}): Promise<
-  NoticesResponseModel['result']
-> => {
+const getNotices = async ({ page = 1, size = 9 }: Props = {}) => {
   try {
-    const response = await axiosInstance.get<NoticesResponseModel>(
-      `/api/notices?page=${page}&size=${size}`
-    )
+    const response = await axiosInstance<NoticesResponseModel>(`/api/notices`, {
+      params: {
+        page,
+        size,
+      },
+    })
     return response.data.result
   } catch (err) {
     console.error(err)

--- a/app/admin/notices/_hook/query/get-admin-notices.ts
+++ b/app/admin/notices/_hook/query/get-admin-notices.ts
@@ -1,0 +1,18 @@
+import getNotices from '@/app/(landing)/notices/_api/get-notice'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+// import getNotices from '../_api/get-notice'
+
+interface Props {
+  page?: number
+  size?: number
+}
+
+const useAdminNotices = ({ page, size }: Props = {}) => {
+  return useSuspenseQuery({
+    queryKey: ['notices', page, size],
+    queryFn: () => getNotices({ page, size }),
+  })
+}
+
+export default useAdminNotices

--- a/shared/api/axios.ts
+++ b/shared/api/axios.ts
@@ -7,7 +7,7 @@ import { isTokenExpired, refreshToken } from '@/shared/utils/token-utils'
 
 export const createAxiosInstance = (options: { withInterceptors?: boolean } = {}) => {
   const instance = axios.create({
-    baseURL: process.env.NEXT_PUBLIC_API_HOST,
+    baseURL: process.env.NEXT_PUBLIC_API_HOST || 'http://localhost:3000',
     withCredentials: true,
   })
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

### 1. axiosInstance에 baseURL 초기값 추가 (제출 직전에 발생한 버그)
> axiosInstance 사용시, next js가 api 요청 경로를 rewrite하기 전에 axiosInstance가 먼저 접근하는 모양입니다.
그래서 axiosInstance의 ```    baseURL: process.env.NEXT_PUBLIC_API_HOST `` 이 부분에서 env가 없는 경우에 axios에선 baseURL이 없는 것으로 판단하여 오류를 내보낸 것으로 추정됩니다. 이를 해결하기 위해 baseURL에 초기값을 추가하는 것으로 해결했습니다.

### 2. 공지사항 불러오는 api에서 불필요한 부분 수정
> 관리자에서도 같이 쓰는 부분이어서 DRY하게 바꿨습니다. 