### PR TITLE
[Design] 테블릿사이즈 위주로 반응형 적용

### DIFF
--- a/app/(dashboard)/_ui/analysis-container/analysis-chart.tsx
+++ b/app/(dashboard)/_ui/analysis-container/analysis-chart.tsx
@@ -38,7 +38,7 @@ const AnalysisChart = ({ analysisChartData: data }: Props) => {
       type: 'areaspline',
       height: 367,
       backgroundColor: 'transparent',
-      margin: [10, 60, 10, 60],
+      margin: [10, 75, 10, 75],
       zoomType: 'x',
     } as Highcharts.ChartOptions,
     title: { text: undefined },
@@ -86,7 +86,7 @@ const AnalysisChart = ({ analysisChartData: data }: Props) => {
       align: 'left',
       verticalAlign: 'top',
       layout: 'vertical',
-      x: 40,
+      x: 70,
       y: -10,
       itemStyle: {
         color: '#4D4D4D',

--- a/app/(dashboard)/_ui/details-information/styles.module.scss
+++ b/app/(dashboard)/_ui/details-information/styles.module.scss
@@ -5,22 +5,29 @@
 }
 
 .name-container {
-  width: 30%;
+  width: 35%;
   height: 144px;
-  padding: 20px;
+  padding: 18px 10px;
   display: flex;
+  justify-content: center;
   flex-direction: column;
-  gap: 10px;
+  gap: 4px;
   border-radius: 5px;
   background-color: $color-white;
   .name {
-    @include typo-h4;
+    @include typo-b1;
   }
   button {
-    height: 36px;
+    height: 30px;
     border-radius: 8px;
-    background-color: $color-gray-100;
+    background-color: $color-gray-200;
     color: $color-gray-700;
+  }
+  @include tablet-md {
+    gap: 2px;
+    button {
+      font-size: $text-b3;
+    }
   }
 }
 
@@ -48,6 +55,9 @@
       @include typo-b3;
       color: $color-gray-700;
       margin-top: 16px;
+      @include tablet-md {
+        font-size: $text-c1;
+      }
     }
   }
 }
@@ -71,12 +81,24 @@
   .label {
     @include typo-b2;
     color: $color-gray-800;
+    @include tablet-md {
+      font-size: $text-b3;
+    }
+    @include tablet-sm {
+      font-size: $text-c1;
+    }
   }
   .percent {
-    @include typo-h3;
+    @include typo-h4;
     color: #f53500;
     &.minus {
       color: #6877ff;
+    }
+    @include tablet-md {
+      font-size: $text-b1;
+    }
+    @include tablet-sm {
+      font-size: $text-b2;
     }
   }
 }

--- a/app/(dashboard)/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/_ui/details-side-item/index.tsx
@@ -43,7 +43,7 @@ const DetailsSideItem = ({
             <div key={item.title}>
               <div className={cx('title')}>{item.title}</div>
               <div className={cx('data')}>
-                <p>{item.data}</p>
+                <p>{typeof item.data === 'number' ? item.data.toFixed(2) : item.data}</p>
               </div>
             </div>
           ))}

--- a/app/(dashboard)/_ui/details-side-item/side-item.tsx
+++ b/app/(dashboard)/_ui/details-side-item/side-item.tsx
@@ -1,10 +1,7 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
-
 import classNames from 'classnames/bind'
 
-import { PATH } from '@/shared/constants/path'
 import useModal from '@/shared/hooks/custom/use-modal'
 import { useAuthStore } from '@/shared/stores/use-auth-store'
 import Avatar from '@/shared/ui/avatar'
@@ -46,12 +43,6 @@ const SideItem = ({
     closeModal: guideCloseModal,
   } = useModal()
   const user = useAuthStore((state) => state.user)
-  const router = useRouter()
-  const path = usePathname()
-
-  const handleRouter = () => {
-    router.push(`${PATH.MY_STRATEGIES}/manage/${strategyId}`)
-  }
 
   const isTrader = user?.role.includes('TRADER')
 
@@ -66,13 +57,8 @@ const SideItem = ({
               <p>{data}</p>
             </div>
             {!isMyStrategy && !isTrader && (
-              <Button onClick={questionOpenModal} size="small" style={{ height: '30px' }}>
+              <Button onClick={questionOpenModal} size="small" style={{ padding: '5px 10px' }}>
                 문의하기
-              </Button>
-            )}
-            {isMyStrategy && !path.includes('my') && (
-              <Button onClick={handleRouter} size="small" style={{ height: '30px' }}>
-                내 전략 관리하기
               </Button>
             )}
           </>

--- a/app/(dashboard)/_ui/details-side-item/styles.module.scss
+++ b/app/(dashboard)/_ui/details-side-item/styles.module.scss
@@ -15,7 +15,7 @@
 
 .side-item,
 .side-items {
-  width: 276px;
+  width: 100%;
   background-color: $color-white;
   border-radius: 5px;
   margin-bottom: 20px;
@@ -42,5 +42,13 @@
   align-items: center;
   p {
     margin: 0 4px 0 11px;
+    @include tablet-md {
+      margin: 0 2px 0 4px;
+    }
   }
+}
+
+.trader-button {
+  height: 30px;
+  padding: 0;
 }

--- a/app/(dashboard)/_ui/introduction/styles.module.scss
+++ b/app/(dashboard)/_ui/introduction/styles.module.scss
@@ -16,7 +16,7 @@
       display: contents;
     }
     p {
-      @include typo-c1;
+      @include typo-b3;
       line-height: 18px;
       color: $color-gray-600;
     }
@@ -34,7 +34,8 @@
       color: $color-gray-500;
       background-color: transparent;
       svg {
-        margin: -3px 0 0 7px;
+        margin-top: -3px;
+        width: 28px;
       }
     }
   }

--- a/app/(dashboard)/_ui/list-header/index.tsx
+++ b/app/(dashboard)/_ui/list-header/index.tsx
@@ -18,7 +18,13 @@ const ListHeader = ({ type = 'default' }: Props) => {
     <div className={cx('container', type)}>
       {LIST_HEADER[type].map((category) => (
         <div key={category} className={cx('category')}>
-          {category}
+          {category === 'SM SCORE' ? (
+            <>
+              <span>SM</span> <span>SCORE</span>
+            </>
+          ) : (
+            category
+          )}
         </div>
       ))}
     </div>

--- a/app/(dashboard)/_ui/list-header/styles.module.scss
+++ b/app/(dashboard)/_ui/list-header/styles.module.scss
@@ -16,10 +16,19 @@
     background-color: $color-white;
     border: 1px solid $color-gray-200;
     border-radius: 4px;
+    padding: 0 2px;
     @include typo-b2;
-
+    @include tablet-md {
+      font-size: $text-b3;
+    }
     &:not(:first-child) {
       margin-left: 5px;
+    }
+    & span:nth-child(2) {
+      margin-left: 2px;
+      @include tablet-md {
+        display: none;
+      }
     }
   }
 }

--- a/app/(dashboard)/_ui/strategies-item/index.tsx
+++ b/app/(dashboard)/_ui/strategies-item/index.tsx
@@ -54,7 +54,7 @@ const StrategiesItem = ({ strategiesData: data, type = 'default' }: Props) => {
           <p>{formatNumber(data.mdd)}</p>
         </div>
         <div className={cx('sm-score')}>
-          <p>{data.smScore}</p>
+          <p>{data.smScore.toFixed(1)}</p>
         </div>
         <div className={cx('profit')}>
           <span>누적 수익률</span>

--- a/app/(dashboard)/_ui/strategies-item/strategies-summary.tsx
+++ b/app/(dashboard)/_ui/strategies-item/strategies-summary.tsx
@@ -42,7 +42,7 @@ const StrategiesSummary = ({
       </div>
       <div className={cx('total-subscribe-star')}>
         <p>구독 {subscriptionCount}개</p>
-        <p>|</p>
+        <span>|</span>
         <TotalStar averageRating={averageRating} totalElements={totalReview} textColor="black" />
       </div>
     </div>

--- a/app/(dashboard)/_ui/strategies-item/styles.module.scss
+++ b/app/(dashboard)/_ui/strategies-item/styles.module.scss
@@ -31,6 +31,9 @@
   .mdd,
   .sm-score {
     @include typo-b2;
+    @include tablet-md {
+      font-size: $text-b3;
+    }
   }
   .profit {
     & span {
@@ -39,6 +42,9 @@
     p {
       @include typo-b2;
       color: $color-orange-500;
+      @include tablet-md {
+        font-size: $text-b3;
+      }
     }
   }
 }
@@ -61,6 +67,10 @@
     & p {
       margin-left: 10px;
       @include typo-b2;
+      @include tablet-md {
+        font-size: $text-b3;
+        margin-left: 4px;
+      }
     }
   }
   .total-subscribe-star {
@@ -69,8 +79,14 @@
     height: 20px;
     gap: 6px;
     padding-top: 10px;
-    & p {
+    & p,
+    span {
       @include typo-c1;
+    }
+    @include tablet-md {
+      & span {
+        display: none;
+      }
     }
   }
 }
@@ -80,6 +96,9 @@
     background: transparent;
     svg {
       width: 36px;
+      @include tablet-md {
+        width: 30px;
+      }
     }
   }
 }
@@ -93,6 +112,9 @@
   display: flex;
   align-items: center;
   column-gap: 4px;
+  overflow: hidden;
+  min-height: 24px;
+  max-height: 48px;
   .icon-wrapper {
     .icon {
       position: relative;

--- a/app/(dashboard)/_ui/subscriber-item/index.tsx
+++ b/app/(dashboard)/_ui/subscriber-item/index.tsx
@@ -2,7 +2,9 @@
 
 import classNames from 'classnames/bind'
 
+import { PATH } from '@/shared/constants/path'
 import { Button } from '@/shared/ui/button'
+import { LinkButton } from '@/shared/ui/link-button'
 
 import styles from './styles.module.scss'
 
@@ -11,11 +13,18 @@ const cx = classNames.bind(styles)
 interface Props {
   isMyStrategy?: boolean
   isSubscribed?: boolean
+  strategyId?: number
   subscribers: number
   onClick?: () => void
 }
 
-const SubscriberItem = ({ isSubscribed, isMyStrategy = false, subscribers, onClick }: Props) => {
+const SubscriberItem = ({
+  isSubscribed,
+  isMyStrategy = false,
+  strategyId,
+  subscribers,
+  onClick,
+}: Props) => {
   return (
     <div className={cx('container')}>
       <div>
@@ -23,10 +32,19 @@ const SubscriberItem = ({ isSubscribed, isMyStrategy = false, subscribers, onCli
         <span>| </span>
         <span>{subscribers}</span>
       </div>
-      {!isMyStrategy && (
+      {!isMyStrategy ? (
         <Button size="small" variant="filled" onClick={onClick}>
           {isSubscribed ? '구독취소' : '구독하기'}
         </Button>
+      ) : (
+        <LinkButton
+          href={`${PATH.MY_STRATEGIES}/manage/${strategyId}`}
+          size="small"
+          variant="filled"
+          className={cx('trader-button')}
+        >
+          관리하기
+        </LinkButton>
       )}
     </div>
   )

--- a/app/(dashboard)/_ui/subscriber-item/styles.module.scss
+++ b/app/(dashboard)/_ui/subscriber-item/styles.module.scss
@@ -13,4 +13,13 @@
     color: $color-gray-800;
     margin-left: 4px;
   }
+  .trader-button {
+    padding: 10px 20px;
+  }
+  @include tablet-md {
+    padding: 0 20px;
+    span {
+      font-size: $text-b2;
+    }
+  }
 }

--- a/app/(dashboard)/strategies/[strategyId]/_ui/review-container/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/review-container/styles.module.scss
@@ -76,13 +76,17 @@
         color: $color-gray-500;
         font-weight: $text-normal;
         margin-right: 5px;
+        @include typo-b3;
       }
     }
   }
   .content {
     margin: 10px 0;
-    font-size: 18px;
-    font-weight: $text-medium;
+    @include typo-b2;
+    font-weight: $text-normal;
+    @include tablet-sm {
+      font-size: $text-b3;
+    }
   }
 }
 

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -81,6 +81,7 @@ const StrategyDetailPage = ({ params }: { params: { strategyId: string } }) => {
                 isSubscribed={information?.isSubscribed}
                 subscribers={information?.subscriptionCount}
                 onClick={openModal}
+                strategyId={strategyNumber}
               />
               {hasDetailsSideData?.[0] &&
                 detailsSideData?.map((data, idx) => (

--- a/app/(dashboard)/strategies/_ui/search-bar/index.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/index.tsx
@@ -41,12 +41,6 @@ const SearchBarContainer = () => {
     }
   }
 
-  const handleEnterSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      onSearch()
-    }
-  }
-
   const onReset = async () => {
     await resetState()
     if (searchRef.current) {
@@ -85,16 +79,17 @@ const SearchBarContainer = () => {
 
   return (
     <>
-      <div className={cx('searchInput-wrapper')}>
+      <div className={cx('search-input-wrapper')}>
         <SearchInput
           ref={searchRef}
+          className={cx('input')}
           placeholder="전략명을 검색하세요."
           onChange={handleSearchWord}
-          onKeyDown={(e) => handleEnterSearch(e)}
           onSearchIconClick={onSearch}
+          maxLength={16}
         />
       </div>
-      <div className={cx('searchInput-wrapper')}>
+      <div className={cx('search-input-wrapper')}>
         <SearchBarTab isMainTab={isMainTab} onChangeTab={setIsMainTab} />
         {isMainTab
           ? ACCORDION_MENU.map((menu) => (

--- a/app/(dashboard)/strategies/_ui/search-bar/styles.module.scss
+++ b/app/(dashboard)/strategies/_ui/search-bar/styles.module.scss
@@ -3,11 +3,16 @@
   justify-content: space-between;
 }
 
-.searchInput-wrapper {
+.search-input-wrapper {
   background-color: $color-white;
   padding: 20px;
   border: 5px;
   margin-bottom: 10px;
+  .input {
+    @include tablet-md {
+      width: 180px;
+    }
+  }
 }
 
 .search-button-wrapper {
@@ -18,9 +23,19 @@
     &.initialize {
       width: 90px;
       padding: 0;
+      @include tablet-md {
+        width: 70px;
+      }
     }
     &.searching {
       width: 140px;
+      @include tablet-md {
+        width: 100px;
+        padding: 0;
+      }
+    }
+    @include tablet-md {
+      font-size: $text-b3;
     }
   }
 }
@@ -39,6 +54,12 @@
     &.main-off {
       background-color: transparent;
       color: $color-gray-700;
+    }
+    @include tablet-md {
+      width: 100px;
+      height: 40px;
+      font-size: $text-b3;
+      padding: 0;
     }
   }
 }
@@ -162,6 +183,9 @@
       span {
         color: $color-gray-600;
       }
+    }
+    @include tablet-md {
+      padding: 4px;
     }
   }
 }

--- a/app/(dashboard)/strategies/_ui/side-container/styles.module.scss
+++ b/app/(dashboard)/strategies/_ui/side-container/styles.module.scss
@@ -3,4 +3,7 @@
   position: absolute;
   right: 0px;
   top: 130px;
+  @include tablet-md {
+    width: 220px;
+  }
 }

--- a/app/(dashboard)/strategies/layout.module.scss
+++ b/app/(dashboard)/strategies/layout.module.scss
@@ -6,5 +6,8 @@
     width: calc(100% - $strategy-sidebar-width);
     max-width: $max-width;
     padding-right: 10px;
+    @include tablet-md {
+      width: calc(100% - #{$strategy-sidebar-width} + 60px);
+    }
   }
 }

--- a/app/(dashboard)/strategies/page.module.scss
+++ b/app/(dashboard)/strategies/page.module.scss
@@ -2,17 +2,6 @@
   margin-top: 80px;
 }
 
-.strategy-layout {
-  display: flex;
-  position: relative;
-
-  .strategy {
-    width: calc(100% - $strategy-sidebar-width);
-    max-width: $max-width;
-    padding-right: 10px;
-  }
-}
-
 .skeleton-side-bar {
   width: $strategy-sidebar-width;
   position: absolute;

--- a/shared/ui/avatar/styles.module.scss
+++ b/shared/ui/avatar/styles.module.scss
@@ -38,6 +38,16 @@ $svg-xxlarge: 110px;
       width: $svg-medium;
       height: $svg-medium;
     }
+
+    @include tablet-md {
+      width: $avatar-small;
+      height: $avatar-small;
+
+      svg {
+        width: $svg-small;
+        height: $svg-small;
+      }
+    }
   }
 
   &.large {

--- a/shared/ui/search-input/index.tsx
+++ b/shared/ui/search-input/index.tsx
@@ -10,18 +10,26 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 interface Props extends ComponentPropsWithoutRef<'input'> {
+  className?: string
   placeholder?: string
   onSearchIconClick?: () => void
 }
 
 const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ placeholder = '', onSearchIconClick, value, onChange, ...props }: Props, ref) => {
+  ({ placeholder = '', className, onSearchIconClick, value, onChange, ...props }: Props, ref) => {
+    const handleEnterSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && onSearchIconClick) {
+        onSearchIconClick()
+      }
+    }
+
     return (
-      <div className={cx('search-input-container')}>
+      <div className={cx('search-input-container', className)}>
         <input
           ref={ref}
           value={value}
           onChange={onChange}
+          onKeyDown={(e) => handleEnterSearch(e)}
           placeholder={placeholder}
           className={cx('search-input')}
           {...props}

--- a/shared/ui/table/statistics/styles.module.scss
+++ b/shared/ui/table/statistics/styles.module.scss
@@ -19,4 +19,12 @@
       border: 1px solid $color-white;
     }
   }
+  @include tablet-md {
+    padding: 10px;
+    table {
+      td {
+        padding: 0 4px;
+      }
+    }
+  }
 }

--- a/shared/ui/table/vertical/styles.module.scss
+++ b/shared/ui/table/vertical/styles.module.scss
@@ -11,12 +11,18 @@
     }
 
     td {
-      padding: 0 20px;
+      padding: 0 4px;
       height: 40px;
       text-align: start;
       vertical-align: middle;
       border-top: 1px solid $color-gray-200;
       border-bottom: 1px solid $color-gray-200;
+    }
+    & td:first-child {
+      padding-left: 20px;
+      @include tablet-md {
+        padding-left: 10px;
+      }
     }
 
     .button-container {
@@ -26,6 +32,9 @@
       padding: 0;
       text-align: right;
     }
+  }
+  @include tablet-md {
+    padding: 10px;
   }
 }
 

--- a/shared/ui/tabs/styles.module.scss
+++ b/shared/ui/tabs/styles.module.scss
@@ -38,4 +38,7 @@
       background-color: $color-orange-500;
     }
   }
+  @include tablet-md {
+    font-size: $text-b2;
+  }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

테블릿사이즈 위주로 반응형 적용

## 🔧 변경 사항

전략 목록, 전략 상세 테블릿사이즈 위주로 반응형 적용했습니다.
- 내 전략일때 관리하기 버튼 위치가 디자인과 달라서 구독쪽으로 수정했습니다.
- searchInput에 onkeyDown 개인적으로 적용해놨는데 동일하게 모두 해놓는게 좋을것같아서 해당컴포넌트 내부로 옮겼습니다

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
