### PR TITLE
[Bug] history stack이 쌓여 발생한 뒤로가기 문제 해결

### DIFF
--- a/app/(dashboard)/traders/[traderId]/page.tsx
+++ b/app/(dashboard)/traders/[traderId]/page.tsx
@@ -42,7 +42,7 @@ const TraderDetailPage = () => {
   return (
     <>
       <div className={cx('page-container')}>
-        <BackHeader label={'목록으로 돌아가기'} href={PATH.TRADERS} />
+        <BackHeader label={'목록으로 돌아가기'} />
         <div className={cx('title')}>
           <Title label={'트레이더 상세보기'} />
         </div>

--- a/shared/hooks/custom/use-pagination.ts
+++ b/shared/hooks/custom/use-pagination.ts
@@ -23,9 +23,12 @@ export const usePagination = ({ basePath, pageSize }: Props): UsePaginationRetur
 
   useEffect(() => {
     if (!searchParams.size) {
-      router.push(`${basePath}?page=1&size=${size ?? pageSize}`)
+      const params = new URLSearchParams(searchParams)
+      params.set('page', String(page))
+      params.set('size', String(size))
+      router.replace(`${basePath}?${params.toString()}`)
     }
-  }, [searchParams, router, basePath, pageSize, size])
+  }, [searchParams, router, basePath, pageSize, size, page])
 
   const handlePageChange = (page: number) => {
     router.push(`${basePath}?page=${page}&size=${pageSize}`)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

페이지네이션 훅에서 history stack이 쌓여 상세 페이지에서 뒤로가기 버튼이 동작하지 않는 오류를 해결했습니다
임시로 backheader에 href를 추가해 동작하도록 되어있었는데
브라우저의 뒤로가기 버튼을 클릭해도 작동할 수 있게 변경했습니다

## 🔧 변경 사항

> 주요 변경 사항을 요약해 주세요. ex) validate 로직 수정, package.json 수정, 파일 수정/삭제 등

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
