### PR TITLE
[Bug] 검색바 에러있을시 데이터 요청가는 에러 해결

### DIFF
--- a/app/(dashboard)/strategies/_hooks/query/use-post-strategies.ts
+++ b/app/(dashboard)/strategies/_hooks/query/use-post-strategies.ts
@@ -15,6 +15,7 @@ const usePostStrategies = ({
   return useQuery({
     queryKey: ['strategies', page, size],
     queryFn: () => postStrategies(page, size, searchTerms),
+    staleTime: 0,
   })
 }
 

--- a/app/(dashboard)/strategies/_ui/search-bar/_store/use-searching-item-store.ts
+++ b/app/(dashboard)/strategies/_ui/search-bar/_store/use-searching-item-store.ts
@@ -15,7 +15,7 @@ interface ActionModel {
   setRangeValue: (key: keyof SearchTermsModel, type: keyof RangeModel, value: number) => void
   setSearchWord: (searchWord: string) => void
   resetState: () => void
-  validateRangeValues: () => void
+  validateRangeValues: () => StateModel['errOptions']
 }
 
 interface ActionsModel {
@@ -95,6 +95,7 @@ const useSearchingItemStore = create<StateModel & ActionsModel>((set, get) => ({
         return false
       })
       set({ errOptions })
+      return errOptions
     },
   },
 }))

--- a/app/(dashboard)/strategies/_ui/search-bar/accordion-button.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/accordion-button.tsx
@@ -2,7 +2,7 @@
 
 import { useContext } from 'react'
 
-import { CloseIcon, OpenIcon } from '@/public/icons'
+import { CloseIcon, ModalAlertIcon, OpenIcon } from '@/public/icons'
 import classNames from 'classnames/bind'
 
 import useSearchingItemStore from './_store/use-searching-item-store'
@@ -21,6 +21,7 @@ interface Props {
 const AccordionButton = ({ optionId, title, size }: Props) => {
   const { openIds, handleButtonIds } = useContext(AccordionContext)
   const searchTerms = useSearchingItemStore((state) => state.searchTerms)
+  const errOptions = useSearchingItemStore((state) => state.errOptions)
 
   const hasOpenId = openIds?.[optionId]
   const clickedValue = searchTerms[optionId]
@@ -30,7 +31,10 @@ const AccordionButton = ({ optionId, title, size }: Props) => {
       <button onClick={() => handleButtonIds(optionId, !hasOpenId)}>
         <p>
           {title}
-          {Array.isArray(clickedValue) &&
+          {errOptions?.includes(optionId) ? (
+            <ModalAlertIcon />
+          ) : (
+            Array.isArray(clickedValue) &&
             clickedValue?.length !== 0 &&
             (clickedValue.length !== size ? (
               <span>
@@ -38,7 +42,8 @@ const AccordionButton = ({ optionId, title, size }: Props) => {
               </span>
             ) : (
               <span>(All)</span>
-            ))}
+            ))
+          )}
         </p>
         {hasOpenId ? <CloseIcon /> : <OpenIcon />}
       </button>

--- a/app/(dashboard)/strategies/_ui/search-bar/accordion-container.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/accordion-container.tsx
@@ -35,10 +35,8 @@ const AccordionContainer = ({ optionId, title, panels }: Props) => {
 
   return (
     <AccordionContext.Provider value={{ openIds, panelRef, handleButtonIds }}>
-      <div>
-        <AccordionButton optionId={optionId} title={title} size={panels?.length} />
-        <AccordionPanel optionId={optionId} panels={panels} />
-      </div>
+      <AccordionButton optionId={optionId} title={title} size={panels?.length} />
+      <AccordionPanel optionId={optionId} panels={panels} />
     </AccordionContext.Provider>
   )
 }

--- a/app/(dashboard)/strategies/_ui/search-bar/index.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/index.tsx
@@ -2,8 +2,12 @@
 
 import { useRef, useState } from 'react'
 
+import { useRouter, useSearchParams } from 'next/navigation'
+
 import classNames from 'classnames/bind'
 
+import { STRATEGIES_PAGE_COUNT } from '@/shared/constants/count-per-page'
+import { PATH } from '@/shared/constants/path'
 import { Button } from '@/shared/ui/button'
 import SearchInput from '@/shared/ui/search-input'
 
@@ -27,13 +31,15 @@ interface AccordionMenuDataModel {
 const SearchBarContainer = () => {
   const [isMainTab, setIsMainTab] = useState(true)
   const searchTerms = useSearchingItemStore((state) => state.searchTerms)
-  const errOptions = useSearchingItemStore((state) => state.errOptions)
-  const { setSearchWord, setAlgorithm, resetState, validateRangeValues } = useSearchingItemStore(
+  const { setSearchWord, setAlgorithm, resetState } = useSearchingItemStore(
     (state) => state.actions
   )
   const searchRef = useRef<HTMLInputElement>(null)
   const { data } = useGetStrategiesSearch()
   const { refetch } = usePostStrategies({ page: 1, size: 8, searchTerms })
+  const params = useSearchParams()
+  const router = useRouter()
+  const page = parseInt(params.get('page') || '1')
 
   const handleSearchWord = () => {
     if (searchRef.current) {
@@ -50,9 +56,13 @@ const SearchBarContainer = () => {
   }
 
   const onSearch = async () => {
-    await validateRangeValues()
-    if (errOptions === null || errOptions.length === 0) {
-      refetch()
+    const { validateRangeValues } = useSearchingItemStore.getState().actions
+    const errOptions = validateRangeValues()
+    if (errOptions?.length === 0) {
+      if (page !== 1) {
+        await router.replace(`${PATH.STRATEGIES}?page=1&size=${STRATEGIES_PAGE_COUNT}`)
+      }
+      await refetch()
     }
   }
 

--- a/app/(dashboard)/strategies/_ui/search-bar/index.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/index.tsx
@@ -36,10 +36,10 @@ const SearchBarContainer = () => {
   )
   const searchRef = useRef<HTMLInputElement>(null)
   const { data } = useGetStrategiesSearch()
-  const { refetch } = usePostStrategies({ page: 1, size: 8, searchTerms })
   const params = useSearchParams()
   const router = useRouter()
   const page = parseInt(params.get('page') || '1')
+  const { refetch } = usePostStrategies({ page, size: 8, searchTerms })
 
   const handleSearchWord = () => {
     if (searchRef.current) {

--- a/app/(dashboard)/strategies/_ui/search-bar/styles.module.scss
+++ b/app/(dashboard)/strategies/_ui/search-bar/styles.module.scss
@@ -108,6 +108,13 @@
         color: $color-orange-500;
         margin-left: 4px;
       }
+      svg {
+        width: 26px;
+        margin: -3px 0 -8px 5px;
+        path {
+          fill: $color-orange-600;
+        }
+      }
     }
     svg {
       width: 26px;

--- a/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
+++ b/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
@@ -26,7 +26,7 @@ const StrategyList = () => {
   })
   const searchTerms = useSearchingItemStore((state) => state.searchTerms)
   const { resetState } = useSearchingItemStore((state) => state.actions)
-  const { data } = usePostStrategies({ page, size, searchTerms })
+  const { data, isLoading } = usePostStrategies({ page, size, searchTerms })
 
   useEffect(() => {
     resetState()
@@ -37,14 +37,20 @@ const StrategyList = () => {
 
   return (
     <>
-      {strategiesData?.map((strategy) => (
-        <StrategiesItem key={strategy.strategyId} strategiesData={strategy} />
-      ))}
-      <div className={cx('pagination')}>
-        {totalPages && (
-          <Pagination currentPage={page} maxPage={totalPages} onPageChange={handlePageChange} />
-        )}
-      </div>
+      {strategiesData?.length > 0 ? (
+        <>
+          {strategiesData.map((strategy) => (
+            <StrategiesItem key={strategy.strategyId} strategiesData={strategy} />
+          ))}
+          <div className={cx('pagination')}>
+            {totalPages && (
+              <Pagination currentPage={page} maxPage={totalPages} onPageChange={handlePageChange} />
+            )}
+          </div>
+        </>
+      ) : (
+        !isLoading && <div className={cx('no-data')}>검색된 전략이 없습니다.</div>
+      )}
     </>
   )
 }

--- a/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
+++ b/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react'
 
+import { usePathname } from 'next/navigation'
+
 import StrategiesItem from '@/app/(dashboard)/_ui/strategies-item'
 import classNames from 'classnames/bind'
 
@@ -27,10 +29,11 @@ const StrategyList = () => {
   const searchTerms = useSearchingItemStore((state) => state.searchTerms)
   const { resetState } = useSearchingItemStore((state) => state.actions)
   const { data, isLoading } = usePostStrategies({ page, size, searchTerms })
+  const path = usePathname()
 
   useEffect(() => {
     resetState()
-  }, [])
+  }, [path])
 
   const strategiesData = data?.content as StrategiesModel[]
   const totalPages = (data?.totalPages as number) || null

--- a/app/(dashboard)/strategies/_ui/strategy-list/styles.module.scss
+++ b/app/(dashboard)/strategies/_ui/strategy-list/styles.module.scss
@@ -1,3 +1,12 @@
 .pagination {
   margin-bottom: 24px;
 }
+
+.no-data {
+  display: flex;
+  justify-content: center;
+  margin-top: 80px;
+  color: $color-gray-600;
+  height: 200px;
+  @include typo-b1;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

검색바 에러있을시 데이터 요청가는 에러 해결

## 🔧 변경 사항

검색바 에러있을시 데이터 요청가는 에러 해결
+ 닫았을때도 에러 아이콘 버튼에 보이도록 추가
+ 검색된 전략 없을 시 ui 추가 
+ 1페이지가 아닌 페이지에서 검색할 시 제대로 요청이 가지 않는 문제 추가로 발견하여 1페이지로 이동 후 데이터 가져오도록 처리

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/3e31fb44-8cb7-485d-abf2-4da5ef505da4)

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
