### PR TITLE
[Design] 일부 디자인 수정 및 나의전략페이지 전략없음UI, 스켈레톤 적용

### DIFF
--- a/app/(dashboard)/my/strategies/_ui/my-strategy-list/index.tsx
+++ b/app/(dashboard)/my/strategies/_ui/my-strategy-list/index.tsx
@@ -4,9 +4,13 @@ import { useCallback, useRef } from 'react'
 
 import StrategiesItem from '@/app/(dashboard)/_ui/strategies-item'
 import { useGetMyStrategyList } from '@/app/(dashboard)/my/_hooks/query/use-get-my-strategy-list'
+import classNames from 'classnames/bind'
 
 import { useIntersectionObserver } from '@/shared/hooks/custom/use-intersection-observer'
 
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
 const MyStrategyList = () => {
   const {
     data: strategyData,
@@ -34,6 +38,7 @@ const MyStrategyList = () => {
   const strategies = strategyData?.pages.flatMap((page) => page.strategies) || []
   return (
     <>
+      {!strategies.length && <p className={cx('no-strategy')}>등록된 나의 전략이 없습니다.</p>}
       {strategies.map((strategy) => (
         <StrategiesItem key={strategy.strategyId} strategiesData={strategy} type="my" />
       ))}

--- a/app/(dashboard)/my/strategies/_ui/my-strategy-list/styles.module.scss
+++ b/app/(dashboard)/my/strategies/_ui/my-strategy-list/styles.module.scss
@@ -1,0 +1,6 @@
+.no-strategy {
+  margin-top: 180px;
+  text-align: center;
+  @include typo-b1;
+  color: $color-gray-600;
+}

--- a/app/(dashboard)/my/strategies/page.tsx
+++ b/app/(dashboard)/my/strategies/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Suspense } from 'react'
+import React, { Suspense } from 'react'
 
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 
 import classNames from 'classnames/bind'
@@ -11,8 +12,15 @@ import { Button } from '@/shared/ui/button'
 import Title from '@/shared/ui/title'
 
 import ListHeader from '../../_ui/list-header'
-import MyStrategyList from './_ui/my-strategy-list'
+import StrategiesItemSkeleton from '../../_ui/strategies-item/skeleton'
 import styles from './styles.module.scss'
+
+const MyStrategyList = React.lazy(() => import('./_ui/my-strategy-list'))
+
+const DynamicStrategySkeleton = dynamic(() => import('../../_ui/strategies-item/skeleton'), {
+  loading: () => <StrategiesItemSkeleton />,
+  ssr: false,
+})
 
 const cx = classNames.bind(styles)
 
@@ -30,10 +38,20 @@ const MyStrategiesPage = () => {
         </Button>
       </div>
       <ListHeader type="my" />
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<Skeleton />}>
         <MyStrategyList />
       </Suspense>
     </div>
+  )
+}
+
+const Skeleton = () => {
+  return (
+    <>
+      {Array.from({ length: 4 }, (_, idx) => (
+        <DynamicStrategySkeleton key={idx} />
+      ))}
+    </>
   )
 }
 

--- a/app/(dashboard)/traders/[traderId]/page.module.scss
+++ b/app/(dashboard)/traders/[traderId]/page.module.scss
@@ -1,5 +1,5 @@
 .page-container {
-  padding: 0 15px;
+  padding: 0 15px 20px;
 }
 
 .title {

--- a/app/(dashboard)/traders/page.module.scss
+++ b/app/(dashboard)/traders/page.module.scss
@@ -17,18 +17,18 @@
 }
 
 .traders-list-wrapper {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 24px 32px;
   margin-bottom: 30px;
 
   @include tablet-md {
-    grid-template-columns: repeat(2, 1fr);
     gap: 16px;
   }
 
   @include mobile {
-    grid-template-columns: 1fr;
     gap: 16px;
   }
 }

--- a/app/(landing)/signin/styles.module.scss
+++ b/app/(landing)/signin/styles.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-top: 150px;
 }
 
 .loginBox {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

일부 디자인 수정 및 나의전략페이지 전략없음UI, 스켈레톤 적용

## 🔧 변경 사항

- 로그인페이지 헤더와 갭 추가
- 트레이더목록페이지 flex-wrap으로 수정
- 나의 전략페이지 전략없음 UI추가
- 나의 전략페이지 스켈레톤 적용

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/fc3f121b-e16a-4bed-9fbc-8f18b37cf606)

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
