### PR TITLE
[Bug] 전략이 없어도 트레이더 상세 페이지가 뜨도록 수정

### DIFF
--- a/app/(dashboard)/traders/[traderId]/page.module.scss
+++ b/app/(dashboard)/traders/[traderId]/page.module.scss
@@ -9,3 +9,14 @@
 .card-wrapper {
   margin-bottom: 54px;
 }
+
+.spinner {
+  margin-top: 200px;
+}
+
+.empty-message {
+  margin-top: 180px;
+  text-align: center;
+  @include typo-b1;
+  color: $color-gray-600;
+}

--- a/app/(dashboard)/traders/[traderId]/page.tsx
+++ b/app/(dashboard)/traders/[traderId]/page.tsx
@@ -8,6 +8,7 @@ import { PATH } from '@/shared/constants/path'
 import { usePagination } from '@/shared/hooks/custom/use-pagination'
 import BackHeader from '@/shared/ui/header/back-header'
 import Pagination from '@/shared/ui/pagination'
+import Spinner from '@/shared/ui/spinner'
 import Title from '@/shared/ui/title'
 import TradersListCard from '@/shared/ui/traders-list-card'
 
@@ -32,11 +33,14 @@ const TraderDetailPage = () => {
   })
 
   const strategies = strategiesData?.content
-  const firstStrategy = strategies?.[0]
   const totalPages = strategiesData?.totalPages
 
-  if (!firstStrategy || isLoading || !totalPages || !traderProfile) {
-    return null
+  if (isLoading) {
+    return <Spinner className={cx('spinner')} />
+  }
+
+  if (!traderProfile) {
+    return <p className={cx('empty-message')}>트레이더 정보를 불러오지 못했습니다.</p>
   }
 
   return (
@@ -60,7 +64,10 @@ const TraderDetailPage = () => {
         {strategies?.map((strategy) => (
           <StrategiesItem key={strategy.strategyId} strategiesData={strategy} />
         ))}
-        <Pagination currentPage={page} maxPage={totalPages} onPageChange={handlePageChange} />
+        {!strategies?.length && <p className={cx('empty-message')}>등록한 전략이 없습니다.</p>}
+        {!!totalPages && (
+          <Pagination currentPage={page} maxPage={totalPages} onPageChange={handlePageChange} />
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략을 아직 등록하지 않은 트레이더도 상세페이지가 보이도록 수정했습니다
(원래는 아무것도 안보였음..)

## 🔧 변경 사항

> 주요 변경 사항을 요약해 주세요. ex) validate 로직 수정, package.json 수정, 파일 수정/삭제 등

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/ffad9963-9fd9-46ae-8b7e-625bd0f5519a)


## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
