### PR TITLE
[Feat] alert modal 공통 컴포넌트 작업 및 관리자 페이지에 적용

### DIFF
--- a/app/admin/notices/_ui/admin-notice-table/index.tsx
+++ b/app/admin/notices/_ui/admin-notice-table/index.tsx
@@ -21,8 +21,8 @@ const AdminNoticeTable = () => {
   }
 
   const tableBody =
-    data?.content.map((data, idx) => [
-      idx + 1,
+    data?.content.map((data) => [
+      data.noticeId,
       data.title,
       data.content.slice(0, 15),
       data.createdAt.slice(0, 10),

--- a/app/admin/notices/_ui/notice-delete-button/index.tsx
+++ b/app/admin/notices/_ui/notice-delete-button/index.tsx
@@ -2,7 +2,9 @@
 
 import classNames from 'classnames/bind'
 
+import useModal from '@/shared/hooks/custom/use-modal'
 import { Button } from '@/shared/ui/button'
+import AlertModal from '@/shared/ui/modal/alert-modal'
 
 import useDeleteNotice from '../../_hook/query/use-delete-notice'
 import styles from './styles.module.scss'
@@ -15,21 +17,28 @@ interface Props {
 
 const NoticeDeleteButton = ({ noticeId }: Props) => {
   const { mutate, isPending } = useDeleteNotice(noticeId)
-
-  const onClick = () => {
-    mutate()
-  }
+  const { closeModal, isModalOpen, openModal } = useModal()
 
   return (
-    <Button
-      size="small"
-      onClick={onClick}
-      disabled={isPending}
-      variant="filled"
-      className={cx('button')}
-    >
-      삭제
-    </Button>
+    <>
+      <Button
+        size="small"
+        onClick={openModal}
+        disabled={isPending}
+        variant="filled"
+        className={cx('button')}
+      >
+        삭제
+      </Button>
+      <AlertModal
+        message={`해당 공지를\n삭제하시겠습니까?`}
+        isModalOpen={isModalOpen}
+        onCancel={closeModal}
+        onConfirm={() => {
+          mutate()
+        }}
+      />
+    </>
   )
 }
 

--- a/app/admin/questions/_ui/admin-question-delete-button/index.tsx
+++ b/app/admin/questions/_ui/admin-question-delete-button/index.tsx
@@ -2,7 +2,9 @@
 
 import classNames from 'classnames/bind'
 
+import useModal from '@/shared/hooks/custom/use-modal'
 import { Button } from '@/shared/ui/button'
+import AlertModal from '@/shared/ui/modal/alert-modal'
 
 import useDeleteQuestion from '../../_hooks/query/use-delete-question'
 import styles from './styles.module.scss'
@@ -14,18 +16,29 @@ interface Props {
 }
 const AdminQuestionDeleteButton = ({ questionId, strategyId }: Props) => {
   const { mutate, isPending } = useDeleteQuestion({ strategyId, questionId })
-  const onClick = () => mutate()
+  const { closeModal, isModalOpen, openModal } = useModal()
+
   return (
-    <Button
-      variant="filled"
-      onClick={onClick}
-      disabled={isPending}
-      size="small"
-      style={{ padding: '7px 16px' }}
-      className={cx('button')}
-    >
-      삭제
-    </Button>
+    <>
+      <Button
+        variant="filled"
+        onClick={openModal}
+        size="small"
+        style={{ padding: '7px 16px' }}
+        className={cx('button')}
+      >
+        삭제
+      </Button>
+      <AlertModal
+        message={`해당 문의내역을\n삭제하시겠습니까?`}
+        isModalOpen={isModalOpen}
+        disabled={isPending}
+        onCancel={closeModal}
+        onConfirm={() => {
+          mutate()
+        }}
+      />
+    </>
   )
 }
 export default AdminQuestionDeleteButton

--- a/app/admin/users/_api/set-table-body.tsx
+++ b/app/admin/users/_api/set-table-body.tsx
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react'
-
 import Avatar from '@/shared/ui/avatar'
 
 import RoleSelect from '../_ui/role-select'
@@ -8,11 +6,9 @@ import { AdminUserInfoModel } from '../types'
 
 interface ArgModel {
   data: AdminUserInfoModel[]
-  openModal: () => void
-  setDeleteUserId: Dispatch<SetStateAction<number>>
 }
 
-const setTableBody = ({ data, openModal, setDeleteUserId }: ArgModel) =>
+const setTableBody = ({ data }: ArgModel) =>
   data.map((data) => {
     return [
       data.userId,
@@ -22,13 +18,7 @@ const setTableBody = ({ data, openModal, setDeleteUserId }: ArgModel) =>
       data.email,
       data.phone,
       <RoleSelect data={data} key={data.userId} />,
-      <UserDeleteButton
-        onClick={() => {
-          openModal()
-          setDeleteUserId(data.userId)
-        }}
-        key={data.userId}
-      />,
+      <UserDeleteButton userId={data.userId} key={data.userId} />,
     ]
   })
 

--- a/app/admin/users/_ui/user-delete-button.tsx
+++ b/app/admin/users/_ui/user-delete-button.tsx
@@ -1,16 +1,34 @@
 'use client'
 
+import useModal from '@/shared/hooks/custom/use-modal'
 import { Button } from '@/shared/ui/button'
+import AlertModal from '@/shared/ui/modal/alert-modal'
+
+import useDeleteUser from '../_hooks/query/use-delete-user'
 
 interface Props {
-  onClick: () => void
+  userId: number
 }
 
-const UserDeleteButton = ({ onClick }: Props) => {
+const UserDeleteButton = ({ userId }: Props) => {
+  const { closeModal, isModalOpen, openModal } = useModal()
+  const { mutate, isPending } = useDeleteUser(userId)
+
   return (
-    <Button variant="filled" onClick={onClick} size="small" style={{ padding: '7px 16px' }}>
-      강제탈퇴
-    </Button>
+    <>
+      <Button variant="filled" onClick={openModal} size="small" style={{ padding: '7px 16px' }}>
+        강제탈퇴
+      </Button>
+      <AlertModal
+        message={`해당 회원을\n탈퇴시키겠습니까?`}
+        isModalOpen={isModalOpen}
+        disabled={isPending}
+        onCancel={closeModal}
+        onConfirm={() => {
+          mutate()
+        }}
+      />
+    </>
   )
 }
 

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,10 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-
 import classNames from 'classnames/bind'
 
-import useModal from '@/shared/hooks/custom/use-modal'
 import Pagination from '@/shared/ui/pagination'
 import SearchInput from '@/shared/ui/search-input'
 import Select from '@/shared/ui/select'
@@ -16,7 +13,6 @@ import AdminContentsHeader from '../_ui/admin-header'
 import setTableBody from './_api/set-table-body'
 import useAdminUsers from './_hooks/query/use-admin-users'
 import useUserSearch from './_hooks/use-user-search-page'
-import UserDeleteModal from './_ui/user-delete-modal'
 import styles from './page.module.scss'
 
 const cx = classNames.bind(styles)
@@ -31,17 +27,12 @@ const AdminUsersPage = () => {
     activeTab,
     inputValue,
     setInputValue,
-    keyword,
-    condition,
     setConditionAndKeyword,
-    currentPage,
     setCurrentPage,
     onTabChange,
   } = useUserSearch()
 
   const { isLoading, data } = useAdminUsers(searchParams)
-  const { isModalOpen, closeModal, openModal } = useModal()
-  const [deleteUserId, setDeleteUserId] = useState<number>(0)
 
   if (isLoading || !data) return null
 
@@ -79,7 +70,7 @@ const AdminUsersPage = () => {
         />
         <VerticalTable
           tableHead={['No.', '프로필', '이름', '닉네임', '이메일', '전화번호', '회원분류', '탈퇴']}
-          tableBody={setTableBody({ data: data?.content, openModal, setDeleteUserId })}
+          tableBody={setTableBody({ data: data?.content })}
           countPerPage={data.size}
           currentPage={1}
         />
@@ -89,7 +80,6 @@ const AdminUsersPage = () => {
           onPageChange={(page) => setCurrentPage(page)}
         />
       </section>
-      <UserDeleteModal userId={deleteUserId} isModalOpen={isModalOpen} closeModal={closeModal} />
     </>
   )
 }

--- a/shared/ui/modal/alert-modal/index.tsx
+++ b/shared/ui/modal/alert-modal/index.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { ModalAlertIcon } from '@/public/icons'
+import classNames from 'classnames/bind'
+
+import { Button } from '@/shared/ui/button'
+import Modal from '@/shared/ui/modal'
+
+import styles from '../styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  isModalOpen: boolean
+  message: string
+  disabled?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const AlertModal = ({ isModalOpen, message, disabled, onConfirm, onCancel }: Props) => {
+  return (
+    <Modal isOpen={isModalOpen} icon={ModalAlertIcon}>
+      <span className={cx('message')}>{message}</span>
+      <div className={cx('two-button')}>
+        <Button onClick={onCancel}>아니오</Button>
+        <Button onClick={onConfirm} disabled={disabled} variant="filled" className={cx('button')}>
+          예
+        </Button>
+      </div>
+    </Modal>
+  )
+}
+
+export default AlertModal


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용
대충 이렇게 생긴 거 alert modal로 만들었습니다.
아이콘과 메시지가 있고, 예/아니오 선택지가 있는 모달입니다.
아이콘명이 alert icon이 길래 alert modal로 작명했습니다.
아니오에 들어갈 로직을 ```onCancel```에, 예에 들어갈 로직을 ```onConfirm```에 넣으면 됩니다.
대부분 onCancel에는 closeModal, onConfirm에는 mutate함수가 들어갈 듯

![alert modal](https://github.com/user-attachments/assets/acc3b4c6-bff7-4d19-a86f-6e96fd06c2dc)

현재 회원 관리, 공지사항, 문의내역에 적용완료됨

