### PR TITLE
[Feat] 관리자 페이지 공지사항 등록 및 수정 첨부파일 목록 출력

### DIFF
--- a/app/admin/notices/[noticeId]/edit/page.module.scss
+++ b/app/admin/notices/[noticeId]/edit/page.module.scss
@@ -36,3 +36,14 @@
   height: 30px;
   border: 1px solid $color-gray-300;
 }
+
+.notice-files-container {
+  width: 640px;
+  margin-left: auto;
+  margin-top: -28px;
+
+  .notice-file-list {
+    @include typo-b3;
+    font-weight: 500;
+  }
+}

--- a/app/admin/notices/[noticeId]/edit/page.tsx
+++ b/app/admin/notices/[noticeId]/edit/page.tsx
@@ -12,6 +12,7 @@ import classNames from 'classnames/bind'
 import { Button } from '@/shared/ui/button'
 import BackHeader from '@/shared/ui/header/back-header'
 import Input from '@/shared/ui/input'
+import NotificationModal from '@/shared/ui/modal/notification-modal'
 import Textarea from '@/shared/ui/textarea'
 import Title from '@/shared/ui/title'
 
@@ -28,7 +29,7 @@ const AdminNoticeEditPage = () => {
   const { data } = useNoticeDetail(Number(noticeId as string))
   const { formData, setFormData, onInputChange } = useNoticeForm()
   const { mutate } = usePatchNotice(formData, Number(noticeId as string))
-  const { handleDeleteFile, handleFileChange } = useFileHandler({
+  const { handleDeleteFile, handleFileChange, isModalOpen, handleCloseModal } = useFileHandler({
     formData,
     setFormData,
     onInputChange,
@@ -118,6 +119,12 @@ const AdminNoticeEditPage = () => {
           </Button>
         </form>
       </div>
+
+      <NotificationModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        message="이미 추가된 파일입니다."
+      />
     </>
   )
 }

--- a/app/admin/notices/[noticeId]/edit/page.tsx
+++ b/app/admin/notices/[noticeId]/edit/page.tsx
@@ -15,6 +15,7 @@ import Input from '@/shared/ui/input'
 import Textarea from '@/shared/ui/textarea'
 import Title from '@/shared/ui/title'
 
+import useFileHandler from '../../_hook/use-file-handler'
 import NoticeFileItem from '../../_ui/notice-file-item'
 import useNoticeForm from '../../post/_hooks/use-notice-form'
 import usePatchNotice from './_hooks/query/use-patch-notice'
@@ -27,6 +28,11 @@ const AdminNoticeEditPage = () => {
   const { data } = useNoticeDetail(Number(noticeId as string))
   const { formData, setFormData, onInputChange } = useNoticeForm()
   const { mutate } = usePatchNotice(formData, Number(noticeId as string))
+  const { handleDeleteFile, handleFileChange } = useFileHandler({
+    formData,
+    setFormData,
+    onInputChange,
+  })
 
   useEffect(() => {
     if (data) {
@@ -37,45 +43,6 @@ const AdminNoticeEditPage = () => {
       })
     }
   }, [data, setFormData])
-
-  const handleDeleteFile = (id: number | string) => {
-    if (typeof id === 'number') {
-      setFormData((prev) => ({
-        ...prev,
-        existingFiles: prev.existingFiles?.filter((file) => file.noticeFileId !== id),
-      }))
-    } else {
-      setFormData((prev) => ({
-        ...prev,
-        newFiles: prev.newFiles?.filter((file) => file.name !== id),
-      }))
-    }
-  }
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFiles = Array.from(e.target.files || [])
-
-    const hasDuplicateFile = (file: File) => {
-      return (
-        formData.existingFiles?.some((existingFile) => existingFile.fileName === file.name) ||
-        formData.newFiles?.some((newFile) => newFile.name === file.name)
-      )
-    }
-
-    const uniqueFiles = selectedFiles.filter((file) => !hasDuplicateFile(file))
-    const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
-
-    if (duplicateFiles.length > 0) {
-      alert('이미 추가된 파일입니다.')
-      return
-    }
-
-    if (uniqueFiles.length > 0) {
-      onInputChange('newFiles', [...(formData.newFiles || []), ...uniqueFiles])
-    }
-
-    e.target.value = ''
-  }
 
   return (
     <>

--- a/app/admin/notices/[noticeId]/edit/page.tsx
+++ b/app/admin/notices/[noticeId]/edit/page.tsx
@@ -84,7 +84,12 @@ const AdminNoticeEditPage = () => {
             <InputField
               label="파일첨부"
               Input={
-                <FileInput className={cx('file-input')} onChange={handleFileChange} multiple />
+                <FileInput
+                  className={cx('file-input')}
+                  onChange={handleFileChange}
+                  multiple
+                  accept=".jpg,.jpeg,.png,.doc,.docx,.pptx,.ppt"
+                />
               }
             />
             <div className={cx('notice-files-container')}>

--- a/app/admin/notices/[noticeId]/edit/page.tsx
+++ b/app/admin/notices/[noticeId]/edit/page.tsx
@@ -66,7 +66,7 @@ const AdminNoticeEditPage = () => {
     const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
 
     if (duplicateFiles.length > 0) {
-      alert('이미 추가된 파일이 있습니다.')
+      alert('이미 추가된 파일입니다.')
       return
     }
 

--- a/app/admin/notices/[noticeId]/edit/page.tsx
+++ b/app/admin/notices/[noticeId]/edit/page.tsx
@@ -15,6 +15,7 @@ import Input from '@/shared/ui/input'
 import Textarea from '@/shared/ui/textarea'
 import Title from '@/shared/ui/title'
 
+import NoticeFileItem from '../../_ui/notice-file-item'
 import useNoticeForm from '../../post/_hooks/use-notice-form'
 import usePatchNotice from './_hooks/query/use-patch-notice'
 import styles from './page.module.scss'
@@ -24,17 +25,57 @@ const cx = classNames.bind(styles)
 const AdminNoticeEditPage = () => {
   const { noticeId } = useParams()
   const { data } = useNoticeDetail(Number(noticeId as string))
-  const { formData, setFormData, onInputChange } = useNoticeForm(data)
-  const { mutate } = usePatchNotice(formData, noticeId as string)
+  const { formData, setFormData, onInputChange } = useNoticeForm()
+  const { mutate } = usePatchNotice(formData, Number(noticeId as string))
 
   useEffect(() => {
     if (data) {
       setFormData({
         title: data.title || '',
         content: data.content || '',
+        existingFiles: data.files || [],
       })
     }
   }, [data, setFormData])
+
+  const handleDeleteFile = (id: number | string) => {
+    if (typeof id === 'number') {
+      setFormData((prev) => ({
+        ...prev,
+        existingFiles: prev.existingFiles?.filter((file) => file.noticeFileId !== id),
+      }))
+    } else {
+      setFormData((prev) => ({
+        ...prev,
+        newFiles: prev.newFiles?.filter((file) => file.name !== id),
+      }))
+    }
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(e.target.files || [])
+
+    const hasDuplicateFile = (file: File) => {
+      return (
+        formData.existingFiles?.some((existingFile) => existingFile.fileName === file.name) ||
+        formData.newFiles?.some((newFile) => newFile.name === file.name)
+      )
+    }
+
+    const uniqueFiles = selectedFiles.filter((file) => !hasDuplicateFile(file))
+    const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
+
+    if (duplicateFiles.length > 0) {
+      alert('이미 추가된 파일이 있습니다.')
+      return
+    }
+
+    if (uniqueFiles.length > 0) {
+      onInputChange('newFiles', [...(formData.newFiles || []), ...uniqueFiles])
+    }
+
+    e.target.value = ''
+  }
 
   return (
     <>
@@ -75,13 +116,35 @@ const AdminNoticeEditPage = () => {
             <InputField
               label="파일첨부"
               Input={
-                <FileInput
-                  className={cx('file-input')}
-                  onChange={(e) => onInputChange('files', Array.from(e.target.files || []))}
-                  multiple
-                />
+                <FileInput className={cx('file-input')} onChange={handleFileChange} multiple />
               }
             />
+            <div className={cx('notice-files-container')}>
+              {formData.existingFiles && formData.existingFiles.length > 0 && (
+                <ul className={cx('notice-file-list')}>
+                  {formData.existingFiles.map((file) => (
+                    <NoticeFileItem
+                      key={file.noticeFileId}
+                      id={file.noticeFileId}
+                      name={file.fileName}
+                      onDeleteFile={handleDeleteFile}
+                    />
+                  ))}
+                </ul>
+              )}
+              {formData.newFiles && formData.newFiles.length > 0 && (
+                <ul className={cx('notice-file-list')}>
+                  {formData.newFiles.map((file) => (
+                    <NoticeFileItem
+                      key={file.name}
+                      id={file.name}
+                      name={file.name}
+                      onDeleteFile={handleDeleteFile}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
           </div>
           <Button size="small" type="submit" variant="filled">
             공지 수정하기

--- a/app/admin/notices/[noticeId]/edit/types.ts
+++ b/app/admin/notices/[noticeId]/edit/types.ts
@@ -1,5 +1,5 @@
 import { APIResponseBaseModel } from '@/shared/types/response'
 
-export interface PatchNoticeResponeseModel extends APIResponseBaseModel<boolean> {
+export interface PatchNoticeResponseModel extends APIResponseBaseModel<boolean> {
   result: string[]
 }

--- a/app/admin/notices/_hook/use-file-handler.ts
+++ b/app/admin/notices/_hook/use-file-handler.ts
@@ -1,4 +1,6 @@
-import { SetStateAction } from 'react'
+'use client'
+
+import { SetStateAction, useState } from 'react'
 
 import { NoticeFileModel, NoticeFormModel } from '../types'
 
@@ -9,6 +11,8 @@ interface UseFileHandlerProps {
 }
 
 const useFileHandler = ({ formData, setFormData, onInputChange }: UseFileHandlerProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
   const hasDuplicateFile = (file: File) => {
     return (
       formData.existingFiles?.some((existingFile) => existingFile.fileName === file.name) ||
@@ -23,7 +27,8 @@ const useFileHandler = ({ formData, setFormData, onInputChange }: UseFileHandler
     const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
 
     if (duplicateFiles.length > 0) {
-      alert('이미 추가된 파일입니다.')
+      setIsModalOpen(true)
+      return
     }
 
     if (uniqueFiles.length > 0) {
@@ -47,9 +52,15 @@ const useFileHandler = ({ formData, setFormData, onInputChange }: UseFileHandler
     }
   }
 
+  const handleCloseModal = () => {
+    setIsModalOpen(false)
+  }
+
   return {
     handleFileChange,
     handleDeleteFile,
+    handleCloseModal,
+    isModalOpen,
   }
 }
 

--- a/app/admin/notices/_hook/use-file-handler.ts
+++ b/app/admin/notices/_hook/use-file-handler.ts
@@ -1,0 +1,56 @@
+import { SetStateAction } from 'react'
+
+import { NoticeFileModel, NoticeFormModel } from '../types'
+
+interface UseFileHandlerProps {
+  formData: NoticeFormModel
+  setFormData: React.Dispatch<SetStateAction<NoticeFormModel>>
+  onInputChange: (name: keyof NoticeFormModel, value: string | File[] | NoticeFileModel[]) => void
+}
+
+const useFileHandler = ({ formData, setFormData, onInputChange }: UseFileHandlerProps) => {
+  const hasDuplicateFile = (file: File) => {
+    return (
+      formData.existingFiles?.some((existingFile) => existingFile.fileName === file.name) ||
+      formData.newFiles?.some((newFile) => newFile.name === file.name)
+    )
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(e.target.files || [])
+
+    const uniqueFiles = selectedFiles.filter((file) => !hasDuplicateFile(file))
+    const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
+
+    if (duplicateFiles.length > 0) {
+      alert('이미 추가된 파일입니다.')
+    }
+
+    if (uniqueFiles.length > 0) {
+      onInputChange('newFiles', [...(formData.newFiles || []), ...uniqueFiles])
+    }
+
+    e.target.value = ''
+  }
+
+  const handleDeleteFile = (id: number | string) => {
+    if (typeof id === 'number') {
+      setFormData((prev) => ({
+        ...prev,
+        existingFiles: prev.existingFiles?.filter((file) => file.noticeFileId !== id),
+      }))
+    } else {
+      setFormData((prev) => ({
+        ...prev,
+        newFiles: prev.newFiles?.filter((file) => file.name !== id),
+      }))
+    }
+  }
+
+  return {
+    handleFileChange,
+    handleDeleteFile,
+  }
+}
+
+export default useFileHandler

--- a/app/admin/notices/_ui/notice-file-item/index.tsx
+++ b/app/admin/notices/_ui/notice-file-item/index.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+interface Props {
+  name: string
+  id: number | string
+  onDeleteFile: (id: number | string) => void
+}
+
+const cx = classNames.bind(styles)
+
+const NoticeFileItem = ({ name, id, onDeleteFile }: Props) => {
+  return (
+    <li className={cx('container')}>
+      <span className={cx('name')}>{name}</span>
+      <button className={cx('button')} type="button" onClick={() => onDeleteFile(id)}>
+        삭제
+      </button>
+    </li>
+  )
+}
+
+export default NoticeFileItem

--- a/app/admin/notices/_ui/notice-file-item/styles.module.scss
+++ b/app/admin/notices/_ui/notice-file-item/styles.module.scss
@@ -1,0 +1,12 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  padding: 0 4px;
+
+  .button {
+    color: $color-gray-800;
+    background-color: transparent;
+  }
+}

--- a/app/admin/notices/post/_hooks/query/use-post-notice.ts
+++ b/app/admin/notices/post/_hooks/query/use-post-notice.ts
@@ -21,17 +21,17 @@ const usePostNotice = () => {
         {
           title: formData.title,
           content: formData.content,
-          filePaths: formData?.files?.map((file) => file.name) ?? [],
-          sizes: formData?.files?.map((file) => file.size) ?? [],
+          filePaths: formData?.newFiles?.map((file) => file.name) ?? [],
+          sizes: formData?.newFiles?.map((file) => file.size) ?? [],
         }
       )
 
-      const { files } = formData
-      if (!files) return
+      const { newFiles } = formData
+      if (!newFiles) return
 
       const presignedUrls = uploadResponse.data.result
 
-      await uploadFileWithPresignedUrl(files, presignedUrls)
+      await uploadFileWithPresignedUrl(newFiles, presignedUrls)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/app/admin/notices/post/_hooks/use-notice-form.ts
+++ b/app/admin/notices/post/_hooks/use-notice-form.ts
@@ -1,17 +1,21 @@
 import { useState } from 'react'
 
-import { NoticeFormModel } from '../../types'
+import { NoticeFileModel, NoticeFormModel } from '../../types'
 
 const useNoticeForm = (
   initialValue = {
     title: '',
     content: '',
-    // files: [],
+    existingFiles: [],
+    newFiles: [],
   }
 ) => {
   const [formData, setFormData] = useState<NoticeFormModel>(initialValue)
 
-  const onInputChange = (name: keyof NoticeFormModel, value: string | File[]) => {
+  const onInputChange = (
+    name: keyof NoticeFormModel,
+    value: string | File[] | NoticeFileModel[]
+  ) => {
     setFormData((prev) => ({
       ...prev,
       [name]: value,

--- a/app/admin/notices/post/page.module.scss
+++ b/app/admin/notices/post/page.module.scss
@@ -36,3 +36,11 @@
   height: 30px;
   border: 1px solid $color-gray-300;
 }
+
+.notice-file-list {
+  @include typo-b3;
+  width: 640px;
+  margin-left: auto;
+  margin-top: -28px;
+  font-weight: 500;
+}

--- a/app/admin/notices/post/page.tsx
+++ b/app/admin/notices/post/page.tsx
@@ -10,6 +10,7 @@ import Title from '@/shared/ui/title'
 
 import FileInput from '../../_ui/file-input'
 import InputField from '../../_ui/input-field'
+import useFileHandler from '../_hook/use-file-handler'
 import NoticeFileItem from '../_ui/notice-file-item'
 import usePostNotice from './_hooks/query/use-post-notice'
 import useNoticeForm from './_hooks/use-notice-form'
@@ -20,35 +21,11 @@ const cx = classNames.bind(styles)
 const AdminNoticePostPage = () => {
   const { formData, onInputChange, setFormData } = useNoticeForm()
   const { mutate: postNotice, isPending } = usePostNotice()
-
-  const handleDeleteFile = (id: string | number) => {
-    setFormData((prev) => ({
-      ...prev,
-      newFiles: prev.newFiles?.filter((file) => file.name !== id),
-    }))
-  }
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFiles = Array.from(e.target.files || [])
-
-    const hasDuplicateFile = (file: File) => {
-      return formData.newFiles?.some((existingFile) => existingFile.name === file.name)
-    }
-
-    const uniqueFiles = selectedFiles.filter((file) => !hasDuplicateFile(file))
-    const duplicateFiles = selectedFiles.filter((file) => hasDuplicateFile(file))
-
-    if (duplicateFiles.length > 0) {
-      alert('이미 추가된 파일입니다.')
-      return
-    }
-
-    if (uniqueFiles.length > 0) {
-      onInputChange('newFiles', [...(formData.newFiles || []), ...uniqueFiles])
-    }
-
-    e.target.value = ''
-  }
+  const { handleDeleteFile, handleFileChange } = useFileHandler({
+    formData,
+    onInputChange,
+    setFormData,
+  })
 
   return (
     <>

--- a/app/admin/notices/post/page.tsx
+++ b/app/admin/notices/post/page.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames/bind'
 import { Button } from '@/shared/ui/button'
 import BackHeader from '@/shared/ui/header/back-header'
 import Input from '@/shared/ui/input'
+import NotificationModal from '@/shared/ui/modal/notification-modal'
 import Textarea from '@/shared/ui/textarea'
 import Title from '@/shared/ui/title'
 
@@ -21,7 +22,7 @@ const cx = classNames.bind(styles)
 const AdminNoticePostPage = () => {
   const { formData, onInputChange, setFormData } = useNoticeForm()
   const { mutate: postNotice, isPending } = usePostNotice()
-  const { handleDeleteFile, handleFileChange } = useFileHandler({
+  const { handleDeleteFile, handleFileChange, isModalOpen, handleCloseModal } = useFileHandler({
     formData,
     onInputChange,
     setFormData,
@@ -87,6 +88,12 @@ const AdminNoticePostPage = () => {
             공지 등록하기
           </Button>
         </form>
+
+        <NotificationModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          message="이미 추가된 파일입니다."
+        />
       </div>
     </>
   )

--- a/app/admin/notices/post/page.tsx
+++ b/app/admin/notices/post/page.tsx
@@ -61,7 +61,7 @@ const AdminNoticePostPage = () => {
               Input={
                 <FileInput
                   className={cx('file-input')}
-                  onChange={(e) => onInputChange('files', Array.from(e.target.files || []))}
+                  onChange={(e) => onInputChange('newFiles', Array.from(e.target.files || []))}
                   multiple
                 />
               }

--- a/app/admin/notices/post/page.tsx
+++ b/app/admin/notices/post/page.tsx
@@ -67,7 +67,12 @@ const AdminNoticePostPage = () => {
             <InputField
               label="파일첨부"
               Input={
-                <FileInput className={cx('file-input')} onChange={handleFileChange} multiple />
+                <FileInput
+                  className={cx('file-input')}
+                  onChange={handleFileChange}
+                  multiple
+                  accept=".jpg,.jpeg,.png,.doc,.docx,.pptx,.ppt"
+                />
               }
             />
             {formData.newFiles && formData.newFiles.length > 0 && (

--- a/app/admin/notices/types.ts
+++ b/app/admin/notices/types.ts
@@ -6,5 +6,11 @@ export interface DeleteNoticeResponeseModel extends APIResponseBaseModel<boolean
 export interface NoticeFormModel {
   title: string
   content: string
-  files?: File[]
+  existingFiles?: NoticeFileModel[]
+  newFiles?: File[]
+}
+
+export interface NoticeFileModel {
+  fileName: string
+  noticeFileId: number
 }

--- a/shared/ui/modal/notification-modal/index.tsx
+++ b/shared/ui/modal/notification-modal/index.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { ModalAlertIcon } from '@/public/icons'
+import classNames from 'classnames/bind'
+
+import { Button } from '@/shared/ui/button'
+import Modal from '@/shared/ui/modal'
+
+import styles from '../styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  isOpen: boolean
+  message: string
+  onClose: () => void
+}
+
+const NotificationModal = ({ isOpen, message, onClose }: Props) => {
+  return (
+    <Modal isOpen={isOpen} icon={ModalAlertIcon}>
+      <span className={cx('message')}>{message}</span>
+      <div className={cx('two-button')}>
+        <Button onClick={onClose}>닫기</Button>
+      </div>
+    </Modal>
+  )
+}
+
+export default NotificationModal


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

관리자가 공지사항을 등록하거나 수정할 때 첨부 파일이 있어도 확인할 수 없어서 첨부파일 인풋 아래에 출력할 수 있도록 수정했습니다!
삭제 버튼을 추가해 잘못 등록한 첨부 파일을 삭제할 수 있도록 구현했습니다.

기존에 등록한 파일을 업로드하려고 할 경우 이미 등록된 파일이라는 안내 문구 모달을 띄워 중복 파일 업로드를 할 수 없도록 구현했습니다

첨부 가능한 확장자도 백엔드 측에서 설정해둔 확장자만 가능하도록 수정했습니다!

## 🔧 변경 사항

> 주요 변경 사항을 요약해 주세요. ex) validate 로직 수정, package.json 수정, 파일 수정/삭제 등

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/72672d0c-0f8f-4add-b045-90d54471b177)

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
