### PR TITLE
[Feat] 랜딩 페이지 전략 카드에 상세 페이지 연결

### DIFF
--- a/app/(landing)/(home)/_ui/top-favorite-section/index.tsx
+++ b/app/(landing)/(home)/_ui/top-favorite-section/index.tsx
@@ -32,6 +32,7 @@ const TopFavoriteSection = () => {
               favoriteStrategies.map((strategy, idx) => (
                 <li key={strategy.strategyId}>
                   <TopFavoriteCard
+                    id={strategy.strategyId}
                     ranking={idx + 1}
                     nickname={strategy.nickname}
                     title={strategy.strategyName}

--- a/app/(landing)/(home)/_ui/top-sm-score-section/index.tsx
+++ b/app/(landing)/(home)/_ui/top-sm-score-section/index.tsx
@@ -26,6 +26,7 @@ const TopSmScoreSection = () => {
             {topSmScoreStrategies.map((strategy, idx) => (
               <li key={strategy.strategyId}>
                 <TopSmScoreCard
+                  id={strategy.strategyId}
                   size={idx > 0 ? 'small' : 'large'}
                   ranking={idx + 1}
                   nickname={strategy.nickname}

--- a/app/(landing)/(home)/_ui/top-strategy-card/index.tsx
+++ b/app/(landing)/(home)/_ui/top-strategy-card/index.tsx
@@ -1,5 +1,8 @@
+import Link from 'next/link'
+
 import classNames from 'classnames/bind'
 
+import { PATH } from '@/shared/constants/path'
 import Avatar from '@/shared/ui/avatar'
 import TotalStar from '@/shared/ui/total-star'
 
@@ -15,12 +18,17 @@ import {
 const cx = classNames.bind(styles)
 
 interface Props {
+  id: number
   size?: CardSizeType
   children: React.ReactNode
 }
 
-const TopStrategyCard = ({ size, children }: Props) => {
-  return <div className={cx('card-container', size)}>{children}</div>
+const TopStrategyCard = ({ id, size, children }: Props) => {
+  return (
+    <Link className={cx('card-container', size)} href={`${PATH.STRATEGIES}/${id}`}>
+      {children}
+    </Link>
+  )
 }
 
 const ContentsWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/app/(landing)/(home)/_ui/top-strategy-card/top-favorite-card.tsx
+++ b/app/(landing)/(home)/_ui/top-strategy-card/top-favorite-card.tsx
@@ -10,6 +10,7 @@ interface Props extends TopStrategyCardCommonProps {
 }
 
 const TopFavoriteCard = ({
+  id,
   ranking,
   nickname,
   title,
@@ -20,7 +21,7 @@ const TopFavoriteCard = ({
   reviewCount,
 }: Props) => {
   return (
-    <TopStrategyCard>
+    <TopStrategyCard id={id}>
       <TopStrategyCard.ContentsWrapper>
         <TopStrategyCard.Content ranking={ranking} nickname={nickname} title={title} />
         <TopStrategyCard.ContentDetails

--- a/app/(landing)/(home)/_ui/top-strategy-card/top-sm-score-card.tsx
+++ b/app/(landing)/(home)/_ui/top-strategy-card/top-sm-score-card.tsx
@@ -11,6 +11,7 @@ interface Props extends TopStrategyCardCommonProps {
 }
 
 const TopSmScoreCard = ({
+  id,
   size = 'small',
   ranking,
   nickname,
@@ -20,7 +21,7 @@ const TopSmScoreCard = ({
   score,
 }: Props) => {
   return (
-    <TopStrategyCard size={size}>
+    <TopStrategyCard size={size} id={id}>
       <TopStrategyCard.ContentsWrapper>
         <TopStrategyCard.Content ranking={ranking} nickname={nickname} title={title} />
         <TopStrategyCard.SmScore score={score} />

--- a/app/(landing)/(home)/_ui/top-strategy-card/types.ts
+++ b/app/(landing)/(home)/_ui/top-strategy-card/types.ts
@@ -22,6 +22,7 @@ export interface TopCardContentDetailsProps {
 }
 
 export interface TopStrategyCardCommonProps {
+  id: number
   ranking: number
   nickname: string
   title: string


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

- 랜딩 페이지의 인기 전략 및 sm 스코어 상위 카드에 상세 페이지로 이동하는 링크 추가

## 🔧 변경 사항

> 주요 변경 사항을 요약해 주세요. ex) validate 로직 수정, package.json 수정, 파일 수정/삭제 등

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
