### PR TITLE
[Design] 실계좌 이미지 width 수정

### DIFF
--- a/shared/ui/modal/account-image-modal.tsx
+++ b/shared/ui/modal/account-image-modal.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const AccountImageModal = ({ isOpen, title, url, onClose }: Props) => {
   return (
-    <Modal isOpen={isOpen} message={title} className={cx('medium')}>
+    <Modal isOpen={isOpen} message={title} className={cx('max')}>
       <div className={cx('image')}>
         <Image src={url} alt={'imageData.title'} fill sizes="100%" />
       </div>

--- a/shared/ui/modal/styles.module.scss
+++ b/shared/ui/modal/styles.module.scss
@@ -40,6 +40,10 @@
   &.big {
     width: 800px;
   }
+  &.max {
+    width: 100%;
+    max-width: 1000px;
+  }
 }
 
 .icon {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략 실계좌 이미지가 잘안보인다고 해서 max-width를 600px에서 1000px로 수정했습니다.
기존에는 medium이라는 클래스가 설정되어 있었는데, medium의 값을 수정하는 대신 max라는 클래스를 추가해 수정했습니다.

## 📸 스크린샷 (권장)

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/f4b5d590-62fc-43f1-91dc-510791713be3" />

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
